### PR TITLE
Fix package-info package line

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/package-info.java
@@ -101,4 +101,4 @@
  * <p>
  * <img src="doc-files/example.png" alt="Example marble diagram">
  */
-package org.eclipse.microprofile.reactive.streams;
+package org.eclipse.microprofile.reactive.streams.operators;

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/spi/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/spi/package-info.java
@@ -26,4 +26,4 @@
  * A TCK is also provided that validates that an implementation is both correct according to this specification, and
  * the Reactive Streams specification.
  */
-package org.eclipse.microprofile.reactive.streams.spi;
+package org.eclipse.microprofile.reactive.streams.operators.spi;


### PR DESCRIPTION
The package line in these files did not match the package they were
actually in, resulting in the package javadoc being missing from the
output.

Fixes #145 