### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.annotation.versioning</artifactId>
                 <version>1.0.0</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -135,9 +135,19 @@
                 <version>6.11</version>
             </dependency>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>2.0</version>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>2.0.2</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.el</groupId>
+                        <artifactId>jakarta.el-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.ejb</groupId>
+                        <artifactId>jakarta.ejb-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -72,8 +72,8 @@
             <artifactId>arquillian-testng-container</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* Switch from the CDI dependency from javax to jakarta
  * Fixes #128
* Exclude the EL and EJB transitive dependencies pulled in the CDI API
  * Fixes #123 
* Make OSGi dependency provided scope
  * Fixes #132 