### PR TITLE
Don't assume DefaultCompletionSubscriber

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/reactive/streams/operators/tck/api/SubscriberBuilderVerification.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/streams/operators/tck/api/SubscriberBuilderVerification.java
@@ -85,7 +85,7 @@ public class SubscriberBuilderVerification extends AbstractReactiveStreamsApiVer
             }
         });
 
-        assertEquals(returned, CompletionSubscriber.of(Mocks.SUBSCRIBER, expectedCs));
+        assertEquals(returned.getCompletion(), expectedCs);
         assertEquals(builtGraph.get().getStages().size(), 1);
         assertTrue(builtGraph.get().getStages().iterator().next() instanceof Stage.Cancel);
     }


### PR DESCRIPTION
Avoid assuming that SubscriberBuilder.build() returns a `DefaultCompletionSubscriber`

Fixes #141 