### PR TITLE
Set package versions and enable baseline check

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -98,18 +98,16 @@
                 <version>3.5.0</version>
                 <configuration>
                     <base>
-                        <version>1.0.0</version>
+                        <version>1.0.1</version>
                     </base>
                 </configuration>
                 <executions>
-                    <!--
                     <execution>
                         <id>baseline</id>
                         <goals>
                             <goal>baseline</goal>
                         </goals>
                     </execution>
-                    -->
                 </executions>
             </plugin>
             <plugin>

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -101,4 +101,5 @@
  * <p>
  * <img src="doc-files/example.png" alt="Example marble diagram">
  */
+@org.osgi.annotation.versioning.Version("1.0")
 package org.eclipse.microprofile.reactive.streams.operators;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,10 @@
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -99,18 +103,16 @@
                 <version>3.5.0</version>
                 <configuration>
                     <base>
-                        <version>1.0.0</version>
+                        <version>1.0.1</version>
                     </base>
                 </configuration>
                 <executions>
-                    <!--
                     <execution>
                         <id>baseline</id>
                         <goals>
                             <goal>baseline</goal>
                         </goals>
                     </execution>
-                    -->
                 </executions>
             </plugin>
         </plugins>

--- a/core/src/main/java/org/eclipse/microprofile/reactive/streams/operators/core/package-info.java
+++ b/core/src/main/java/org/eclipse/microprofile/reactive/streams/operators/core/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,14 +17,5 @@
  * limitations under the License.
  ******************************************************************************/
 
-/**
- * The Reactive Streams utils SPI.
- *
- * Implementors are expected to implement the {@code ReactiveStreamsEngine} interface, and use this SPI to inspect
- * the graph of stages.
- *
- * A TCK is also provided that validates that an implementation is both correct according to this specification, and
- * the Reactive Streams specification.
- */
 @org.osgi.annotation.versioning.Version("1.0")
-package org.eclipse.microprofile.reactive.streams.operators.spi;
+package org.eclipse.microprofile.reactive.streams.operators.core;


### PR DESCRIPTION
* Set package versions appropriately based on changes since 1.0.1
* Enable the bnd-baseline-maven-plugin