### PR TITLE
Clarify that Builders are immutable

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/ProcessorBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/ProcessorBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -46,6 +46,8 @@ import java.util.stream.Collector;
  * Below is an example diagram labelling all the parts of the stream.
  * <p>
  * <img src="doc-files/example.png" alt="Example marble diagram">
+ * <p>
+ * Instances of this interface are immutable. Methods which return a {@code ProcessorBuilder} will return a new instance.
  *
  * @param <T> The type of the elements that the processor consumes.
  * @param <R> The type of the elements that the processor emits.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/PublisherBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/PublisherBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -46,6 +46,8 @@ import java.util.stream.Collector;
  * Below is an example diagram labelling all the parts of the stream.
  * <p>
  * <img src="doc-files/example.png" alt="Example marble diagram">
+ * <p>
+ * Instances of this interface are immutable. Methods which return a {@code PublisherBuilder} will return a new instance.
  *
  * @param <T> The type of the elements that the publisher emits.
  * @see ReactiveStreams


### PR DESCRIPTION
This is already implied by the fact that each method which returns a
PublisherBuilder or ProcessorBuilder states that it returns a new
instance, but it's helpful to be explicit in the class javadoc.

Fixes #142