### PR TITLE
Update microprofile-parent version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ release.conf
 /bin/
 .~lock.*.odg#
 **.DS_Store
+.vscode

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <properties>
-        <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>1.11.0</frontend-maven-plugin.version>
         <bnd.baseline.include.distribution.management>false</bnd.baseline.include.distribution.management>
     </properties>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2018, 2023 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/ConnectingOperators.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/ConnectingOperators.java
@@ -78,7 +78,7 @@ public interface ConnectingOperators<T> {
      * in, so the resulting stream should only be run once. For the same reason, the processor passed in should not have
      * any active subscriptions and should not be used in more than one call to this method.
      *
-     * 
+     *
      * @param processor
      *            The processor builder to connect.
      * @return A stream builder that represents the passed in processor builder's outlet.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/ProcessorBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/ProcessorBuilder.java
@@ -158,7 +158,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A {@link SubscriberBuilder} that will invoke the action for each element of the stream.
      */
     @Override
@@ -166,7 +166,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link SubscriberBuilder} for the stream.
      */
     @Override
@@ -174,7 +174,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link SubscriberBuilder} for the stream.
      */
     @Override
@@ -182,7 +182,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link SubscriberBuilder} for the reduction.
      */
     @Override
@@ -190,7 +190,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link SubscriberBuilder} for the reduction.
      */
     @Override
@@ -198,7 +198,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link SubscriberBuilder} that will emit the collected result.
      */
     @Override
@@ -206,7 +206,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link SubscriberBuilder} that will emit the collected result.
      */
     @Override
@@ -214,7 +214,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link SubscriberBuilder} that will emit the list.
      */
     @Override
@@ -222,7 +222,7 @@ public interface ProcessorBuilder<T, R>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link SubscriberBuilder}.
      */
     @Override

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/PublisherBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/PublisherBuilder.java
@@ -155,7 +155,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream.
      */
     @Override
@@ -163,7 +163,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream.
      */
     @Override
@@ -171,7 +171,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream.
      */
     @Override
@@ -179,7 +179,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream.
      */
     @Override
@@ -187,7 +187,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream.
      */
     @Override
@@ -195,7 +195,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream.
      */
     @Override
@@ -203,7 +203,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream, R is the result type of the
      *         collector's reduction operation.
      */
@@ -211,7 +211,7 @@ public interface PublisherBuilder<T>
     <R, A> CompletionRunner<R> collect(Collector<? super T, A, R> collector);
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream which emits the collected result.
      */
     @Override
@@ -219,7 +219,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the stream that emits the list.
      */
     @Override
@@ -246,7 +246,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the composed stream.
      */
     @Override
@@ -254,7 +254,7 @@ public interface PublisherBuilder<T>
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return A new {@link CompletionRunner} that can be used to run the composed stream.
      */
     @Override
@@ -282,7 +282,7 @@ public interface PublisherBuilder<T>
      * Build this stream, using the supplied {@link ReactiveStreamsEngine}. This method is designed for the use case
      * where you have to supply a paritcular {@link ReactiveStreamsEngine}. Most cases you should use
      * {@link #buildRs()}.
-     * 
+     *
      * @param engine
      *            The engine to run the stream with.
      * @return A {@link Publisher} that will run this stream.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/operators/package-info.java
@@ -65,7 +65,7 @@
  * you want to output it as a comma separated list of lines to publish to an HTTP client request body, which expects a
  * {@link org.reactivestreams.Publisher} of {@link java.nio.ByteBuffer}. Here's how this might be implemented:
  * <p>
- * 
+ *
  * <pre>
  *   Publisher&lt;Row&gt; rowsPublisher = ...;
  *

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.5</version>
+        <version>2.8</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
@@ -33,6 +33,7 @@
 
     <properties>
         <inceptionYear>2018</inceptionYear>
+        <version.microprofile.tck.bom>2.8</version.microprofile.tck.bom>
     </properties>
 
     <name>Eclipse MicroProfile Reactive Streams Operators</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2018, 2023 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -45,6 +45,18 @@
     <name>Eclipse MicroProfile Reactive Streams Operators TCK</name>
     <description>Eclipse MicroProfile Reactive Streams Operators :: TCK</description>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.microprofile</groupId>
+                <artifactId>microprofile-tck-bom</artifactId>
+                <version>${version.microprofile.tck.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2018, 2023 Contributors to the Eclipse Foundation
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/streams/operators/tck/arquillian/ReactiveStreamsArquillianTck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/streams/operators/tck/arquillian/ReactiveStreamsArquillianTck.java
@@ -19,6 +19,7 @@
 
 package org.eclipse.microprofile.reactive.streams.operators.tck.arquillian;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -37,15 +38,14 @@ import org.reactivestreams.tck.TestEnvironment;
 import org.testng.IClassListener;
 import org.testng.IMethodInstance;
 import org.testng.IMethodInterceptor;
-import org.testng.IObjectFactory;
 import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestNGListener;
+import org.testng.ITestObjectFactory;
 import org.testng.ITestResult;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
-import org.testng.internal.ObjectFactoryImpl;
 
 import jakarta.inject.Inject;
 
@@ -78,18 +78,40 @@ public class ReactiveStreamsArquillianTck extends Arquillian {
     @Inject
     private ReactiveStreamsCdiTck tck;
 
+    private class TCKObjectFactory implements ITestObjectFactory {
+        @Override
+        public <T> T newInstance(Class<T> cls, Object... parameters) {
+            if (cls.equals(ReactiveStreamsCdiTck.class)) {
+                return (T) tck;
+            } else {
+                return ITestObjectFactory.super.newInstance(cls, parameters);
+            }
+        }
+
+        @Override
+        public <T> T newInstance(String clsName, Object... parameters) {
+            if (clsName.equals(ReactiveStreamsCdiTck.class.getName())) {
+                return (T) tck;
+            } else {
+                return ITestObjectFactory.super.newInstance(clsName, parameters);
+            }
+        }
+
+        @Override
+        public <T> T newInstance(Constructor<T> constructor, Object... parameters) {
+            if (constructor.getDeclaringClass().equals(ReactiveStreamsCdiTck.class)) {
+                return (T) tck;
+            } else {
+                return ITestObjectFactory.super.newInstance(constructor, parameters);
+            }
+        }
+    }
+
     @Test
     public void runAllTckTests() throws Throwable {
         TestNG testng = new TestNG();
 
-        ObjectFactoryImpl delegate = new ObjectFactoryImpl();
-        testng.setObjectFactory((IObjectFactory) (constructor, params) -> {
-            if (constructor.getDeclaringClass().equals(ReactiveStreamsCdiTck.class)) {
-                return tck;
-            } else {
-                return delegate.newInstance(constructor, params);
-            }
-        });
+        testng.setObjectFactory(new TCKObjectFactory());
 
         testng.setUseDefaultListeners(false);
         ResultListener resultListener = new ResultListener();

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/streams/operators/tck/arquillian/ReactiveStreamsArquillianTck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/streams/operators/tck/arquillian/ReactiveStreamsArquillianTck.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.


### PR DESCRIPTION
The main aim of this PR is to update the version of `microprofile-parent` to 2.8. This also has the effect of updating the version of TestNG to 7.5.1. The Arquillian runner `ReactiveStreamsArquillianTck` was using some TestNG internals which have now been moved. So instead of using internals, we have changed to using just APIs.

The version of the `frontend-maven-plugin` has also been updated to one which works on an M1 Mac.
Rebuilding with the new microprofile-parent version has also resulted in some minor changes to javadoc in a couple of API classes.